### PR TITLE
Upgrade Hugo to 0.161.1, fix deprecated .Site.LanguageCode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 0.122.0
+          hugo-version: 0.161.1
           extended: true
 
       - name: Run Hugo

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-hugo extended_0.122.0
+hugo extended_0.161.1

--- a/themes/nightfall/layouts/_default/baseof.html
+++ b/themes/nightfall/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
 <head>
     <title>{{ block "title" . }}

--- a/themes/nightfall/layouts/index.html
+++ b/themes/nightfall/layouts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
 <head>
     <title>


### PR DESCRIPTION
- Bump hugo version to 0.161.1 in .tool-versions and CI workflow
- Replace deprecated .Site.LanguageCode with .Site.Language.Locale in themes/nightfall/layouts/_default/baseof.html and index.html